### PR TITLE
nis_call.c: Include stdint.h for uintptr_t definition

### DIFF
--- a/src/nisplus/nis_call.c
+++ b/src/nisplus/nis_call.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
+#include <stdint.h>
 #include <libintl.h>
 #include <rpc/rpc.h>
 #include <rpc/auth.h>


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>