### PR TITLE
Fix gettext infrastructure mismatch error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,9 @@ if test -n "$TIRPC_LIBS"; then
 fi
 
 dnl internationalization macros
+m4_ifndef([AM_GNU_GETTEXT_REQUIRE_VERSION],
+  [m4_define([AM_GNU_GETTEXT_REQUIRE_VERSION], [])])
+AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.2])
 AM_GNU_GETTEXT_VERSION([0.19.2])
 AM_GNU_GETTEXT([external])
 


### PR DESCRIPTION
AM_GNU_GETTEXT_VERSION instructs autopoint/gettextize to use an exact
version of gettext infrastructure.

To handle version upgrades gettext-0.19.6 added
AM_GNU_GETTEXT_REQUIRE_VERSION which instructs these to use the latest
available infrastructure which satisfies a version requirement.