### PR TITLE
nisplus: Fix leak on realloc failure in nis_getnames

### DIFF
--- a/src/nisplus/nis_subr.c
+++ b/src/nisplus/nis_subr.c
@@ -106,9 +106,6 @@ count_dots (const_nis_name str)
   return count;
 }
 
-/* If we run out of memory, we don't give already allocated memory
-   free. The overhead for bringing getnames back in a safe state to
-   free it is to big. */
 nis_name *
 nis_getnames (const_nis_name name)
 {
@@ -274,7 +271,10 @@ nis_getnames (const_nis_name name)
 	      nis_name *newp = realloc (getnames,
 					(count + 1) * sizeof (char *));
 	      if (newp == NULL)
-		goto free_null;
+		{
+		  free (newp);
+		  goto free_null;
+		}
 	      getnames = newp;
 	    }
 	  getnames[pos] = tmp;


### PR DESCRIPTION
If pos >= count but realloc fails, tmp will not have been placed in
getnames[pos] yet, and so will not be freed in free_null.  Detected
by Coveriy.

Also remove misleading comment from nis_getnames(), since it actually
did properly release getnames when out of memory.

Corresponds to glibc commit 60698263122b7c54ded3f70a466176e17a529480

Signed-off-by: Robbie Harwood <rharwood@redhat.com>