### PR TITLE
Remove unused internal symbols from libnsl.map

### DIFF
--- a/src/libnsl.map
+++ b/src/libnsl.map
@@ -15,7 +15,6 @@ LIBNSL_2.0 {
     xdr_ypbind3_setdom;
     xdr_ypbind_oldsetdom;
     xdr_ypbind_resptype;
-    xdr_ypcall;
     xdr_ypmap_parms;
     xdr_ypmaplist;
     xdr_yppushresp_xfr;
@@ -48,15 +47,4 @@ LIBNSL_2.0 {
 
   local:
     *;
-};
-
-LIBNSL_PRIVATE {
-  global:
-    __create_ib_request;
-    __do_niscall3;
-    __follow_path;
-    __nisbind_destroy;
-    __prepare_niscall;
-    _xdr_ib_request;
-    _xdr_nis_result;
 };


### PR DESCRIPTION
* Initially added in 9b521d32fedc1c6cc760b3bca9a56fd4b25a7f5f.
* But symbols were removed in 99113995464fae4dc19c745e9f7a163cf0da5d13.
* xdr_ypcall was specifically added to the file in
  https://github.com/thkukuk/libnsl/commit/7199c1d2d8511a31ca0209a1690f6338627ea43a, but the symbol wasn't
  defined at the time either.
  
```
libtool: link: clang -shared  -fPIC -DPIC  .libs/yp_xdr.o .libs/do_ypcall.o .libs/ypprot_err.o .libs/yp_master.o .libs/yp_maplist.o .libs/yp_order.o .libs/yp_first.o .libs/yp_next.o .libs/yp_match.o .libs/yperr_string.o .libs/ypbinderr_string.o .libs/yp_get_default_domain.o .libs/taddr2host.o .libs/taddr2ipstr.o .libs/taddr2port.o   -ltirpc  -O3 -march=znver3 -flto=thin -Wl,--no-undefined -Wl,--version-script=/var/tmp/portage/net-libs/libnsl-2.0.0-r1/work/libnsl-2.0.0/src/libnsl.map -Wl,-O1 -Wl,--as-needed -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0   -Wl,-soname -Wl,libnsl.so.3 -o .libs/libnsl.so.3.0.0
ld.lld: error: version script assignment of 'LIBNSL_2.0' to symbol 'xdr_ypcall' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '__create_ib_request' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '__do_niscall3' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '__follow_path' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '__nisbind_destroy' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '__prepare_niscall' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '_xdr_ib_request' failed: symbol not defined
ld.lld: error: version script assignment of 'LIBNSL_PRIVATE' to symbol '_xdr_nis_result' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Bug: https://bugs.gentoo.org/915152
