### PR TITLE
Make ypbindlist_lock recursive

### DIFF
--- a/src/do_ypcall.c
+++ b/src/do_ypcall.c
@@ -45,7 +45,7 @@ typedef struct dom_binding dom_binding;
 
 static const struct timeval RPCTIMEOUT = {25, 0};
 static int const MAXTRIES = 2;
-static pthread_mutex_t ypbindlist_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t ypbindlist_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 static dom_binding *ypbindlist = NULL;
 static __thread int from_yp_all = 0;
 


### PR DESCRIPTION
Hi, 

I have a hang inside the libnsl.so

```
#0  0x00007efdf088b84d in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007efdf0884ac9 in pthread_mutex_lock () from /lib64/libpthread.so.0
#2  0x00007efde018926e in do_ypcall (domain=0x7efde038c260 <ypdomainname> "mydomain", prog=prog@entry=3, xargs=0x7efde0188220 <xdr_ypreq_key>, req=req@entry=0x7ffc5b747690 "`\302\070\340\375~", xres=xres@entry=0x7efde0188370 <xdr_ypresp_val>, resp=resp@entry=0x7ffc5b747670 "") at do_ypcall.c:409
#3  0x00007efde01894b9 in do_ypcall_tr (domain=<optimized out>, prog=prog@entry=3, xargs=<optimized out>, req=req@entry=0x7ffc5b747690 "`\302\070\340\375~", xres=xres@entry=0x7efde0188370 <xdr_ypresp_val>, resp=resp@entry=0x7ffc5b747670) at do_ypcall.c:475
#4  0x00007efde0189d28 in yp_match (indomain=<optimized out>, inmap=inmap@entry=0x7efdde4cd7c7 "hosts.byname", inkey=inkey@entry=0x7ffc5b7476e0 "mynis.local", inkeylen=<optimized out>, outval=outval@entry=0x7ffc5b747740, outvallen=outvallen@entry=0x7ffc5b747734) at yp_match.c:48
#5  0x00007efdde4c70e0 in internal_gethostbyname2_r (name=name@entry=0x5632e22c2b00 "mynis.local", af=af@entry=2, host=host@entry=0x7ffc5b747950, buffer=buffer@entry=0x7ffc5b747bd0 "\177", buflen=buflen@entry=1024, errnop=errnop@entry=0x7efdf1eb6910, h_errnop=0x7efdf1eb697c, flags=0) at nis-hosts.c:290
#6  0x00007efdde4c76fc in _nss_nis_gethostbyname2_r (name=0x5632e22c2b00 "mynis.local", af=2, host=0x7ffc5b747950, buffer=0x7ffc5b747bd0 "\177", buflen=1024, errnop=0x7efdf1eb6910, h_errnop=0x7efdf1eb697c) at nis-hosts.c:353
#7  0x00007efdf05f3e7d in gethostbyname2_r@@GLIBC_2.2.5 () from /lib64/libc.so.6
#8  0x00007efdf05cb070 in gaih_inet.constprop () from /lib64/libc.so.6
#9  0x00007efdf05cbddb in getaddrinfo () from /lib64/libc.so.6
#10 0x00007efddff670a0 in getclnthandle () from /lib64/libtirpc.so.3
#11 0x00007efddff67dc7 in __rpcb_findaddr_timed () from /lib64/libtirpc.so.3
#12 0x00007efddff60154 in clnt_tp_create_timed () from /lib64/libtirpc.so.3
#13 0x00007efddff60311 in clnt_create_timed () from /lib64/libtirpc.so.3
#14 0x00007efde01889ab in yp_bind_client_create_v3 (domain=domain@entry=0x7efde038c260 <ypdomainname> "mydomain", ysd=ysd@entry=0x5632e22f78d0, ypb3=ypb3@entry=0x7ffc5b748390) at do_ypcall.c:75
#15 0x00007efde0188fa4 in yp_bind_file (ysd=0x5632e22f78d0, domain=0x7efde038c260 <ypdomainname> "mydomain") at do_ypcall.c:120
#16 __yp_bind (domain=domain@entry=0x7efde038c260 <ypdomainname> "mydomain", ypdb=ypdb@entry=0x7efde038c200 <ypbindlist>) at do_ypcall.c:275
#17 0x00007efde01891b3 in __yp_bind (ypdb=0x7efde038c200 <ypbindlist>, domain=0x7efde038c260 <ypdomainname> "mydomain") at do_ypcall.c:320
#18 yp_bind (indomain=0x7efde038c260 <ypdomainname> "mydomain") at do_ypcall.c:320
#19 0x00007efde03931f3 in _unix_getpwnam (pamh=pamh@entry=0x5632e22ee340, name=0x5632e22c0740 "service", files=files@entry=0, nis=nis@entry=1, ret=ret@entry=0x0) at support.c:405
#20 0x00007efde03936bc in _unix_comesfromsource (pamh=pamh@entry=0x5632e22ee340, name=<optimized out>, files=files@entry=0, nis=nis@entry=1) at support.c:521
#21 0x00007efde039195f in pam_sm_chauthtok (pamh=0x5632e22ee340, flags=<optimized out>, argc=<optimized out>, argv=<optimized out>) at pam_unix_passwd.c:669
#22 0x00007efdf10fd7b4 in _pam_dispatch_aux (use_cached_chain=<optimized out>, resumed=<optimized out>, h=0x5632e22f6c20, flags=16384, pamh=0x5632e22ee340) at pam_dispatch.c:110
#23 _pam_dispatch (pamh=pamh@entry=0x5632e22ee340, flags=flags@entry=16384, choice=choice@entry=6) at pam_dispatch.c:426
#24 0x00007efdf110200c in pam_chauthtok (pamh=0x5632e22ee340, flags=0) at pam_password.c:41
#25 0x00005632e1a10c0f in main (argc=2, argv=<optimized out>) at passwd.c:546

```

there is only one thread (LWP 33838):

```
(gdb) info threads
  Id   Target Id                                  Frame 
* 1    Thread 0x7efdf1eb6a80 (LWP 33838) "passwd" 0x00007efdf088b84d in __lll_lock_wait () from /lib64/libpthread.so.0
```

And the mutex is locked by the same thread:

```
(gdb) p ypbindlist_lock
$1 = {__data = {__lock = 2, __count = 0, __owner = 33838, __nusers = 1, __kind = 0, __spins = 0, __elision = 0, __list = {__prev = 0x0, __next = 0x0}}, __size = "\002\000\000\000\000\000\000\000.\204\000\000\001", '\000' <repeats 26 times>, __align = 2}
```

The reason is that `yp_bind` locks the mutex `ypbindlist_lock` and then down the stack `do_ypcall` tries to lock the same mutex again, which is resulting in deadlock because the mutex is non-recursive:

```
static pthread_mutex_t ypbindlist_lock = PTHREAD_MUTEX_INITIALIZER;
```

My solution is to change this mutex to recursive (Linux-specific static initializer for recursive mutexes):

```
PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
```

Please let me know if this code should be portable. In this case I guess I can change it from static initializer to `pthread_mutex_init`.