### PR TITLE
Minor tweaks to libnsl.pc.in

### DIFF
--- a/libnsl.pc.in
+++ b/libnsl.pc.in
@@ -3,10 +3,9 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: libnsl
+Name: @PACKAGE_NAME@
 Description: Library containing NIS functions using TI-RPC (IPv6 enabled)
 Requires: libtirpc >= 1.0.1
 Version: @PACKAGE_VERSION@
-Libs: -L@libdir@ -lnsl
-Cflags: -I@includedir@
-
+Libs: -L${libdir} -lnsl
+Cflags: -I${includedir}


### PR DESCRIPTION
This uses the examples from https://tecnocode.co.uk/2014/12/09/a-checklist-for-writing-pkg-config-files/ to make `libnsl.pc.in` more closely follow common conventions for `.pc.in` files.

Specifically, we want the `-L` flag to reuse the `${libdir}` variable rather than using the `@libdir@` placeholder directly, as this eases downstream rewrites/adjustments of this file.